### PR TITLE
Travis build apunta a nueva URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Swagger](http://online.swagger.io/validator?url=https://raw.githubusercontent.com/Multicaja/API-Multicaja_digital/master/api-users.yml)](https://raw.githubusercontent.com/Multicaja/API-Multicaja_digital/master/api-users.yml) [![TravisCI](https://travis-ci.org/Multicaja/API-Multicaja_digital.svg?branch=master)](https://travis-ci.org/Multicaja/API-Multicaja_digital/)
+[![Swagger](http://online.swagger.io/validator?url=https://raw.githubusercontent.com/Multicaja/api/master/api-users.yml)](https://raw.githubusercontent.com/Multicaja/api/master/api-users.yml) [![TravisCI](https://travis-ci.org/Multicaja/api.svg?branch=master)](https://travis-ci.org/Multicaja/api/)
  
 ## API Multicaja Digital
 

--- a/api-spec_validation_test.sh
+++ b/api-spec_validation_test.sh
@@ -8,7 +8,7 @@ setUp()
   # Setup local variables to dynamically generate the API spec URL from pull request.
   githubRawResourceBaseUrl=https://raw.githubusercontent.com
   githubUsername=Multicaja
-  githubProjectId=API-Multicaja_digital
+  githubProjectId=api
   openApiSpecFileName=api-users.yml
   
 


### PR DESCRIPTION
Antes `/API-Multicaja_digital`, ahora `/api`