### PR TITLE
Aceptar terminos y condiciones de prepago

### DIFF
--- a/api-prepaid.yml
+++ b/api-prepaid.yml
@@ -764,6 +764,41 @@ paths:
           schema:
             $ref: '#/definitions/error_obj'
 
+  /prepaid/{user_id}/tac:
+    post:
+      tags:
+        - prepaid
+      summary: Aceptar Terminos y Condiciones
+      description: |
+        Aceptar los beneficios y los terminos y condiciones del producto Prepago
+      parameters:
+        - in: body
+          name: new_tac
+          description: Detalle
+          required: true
+          schema:
+            $ref: '#/definitions/prepaid_tac_new'
+      responses:
+        '201':
+          description: |
+            OK
+        '400':
+          description: Error en parámetros, se lanza a cuando un parámetro es requerido y no se ha enviado
+          schema:
+            $ref: '#/definitions/error_obj'
+        '404':
+          description: Cliente no existe o no tiene prepago
+          schema:
+            $ref: '#/definitions/error_obj'
+        '422':
+          description: Error de validación de negocio, revise error
+          schema:
+            $ref: '#/definitions/error_obj'        
+        '500':
+          description: Error indeterminado, se lanza cuando ocurre un error imprevisto de sistema
+          schema:
+            $ref: '#/definitions/error_obj'
+
 definitions:
 
   prepaid_topup_base:
@@ -1115,6 +1150,7 @@ definitions:
       method:
         type: string
         enum: ['POS', 'WEB']
+  
   simulation_group:
     type: object
     description: Retorna simulacion web y pos
@@ -1343,3 +1379,25 @@ definitions:
         $ref: '#/definitions/amount_and_currency_new'
       amount_secondary:
         $ref: '#/definitions/amount_and_currency_new'
+
+  prepaid_tac_new:
+    type: object
+    description: |
+      Contenido mínimo de una carga
+    properties:
+      terms_and_conditions_version:
+        type: string
+        description: |
+          Version de los terminos y condiciones aceptados por el usuario
+        example: "v1.0"
+      terms_and_conditions_accepted:
+        type: boolean
+        description: |
+          Cliente acepta los terminos y condiciones
+        example: true
+      benefits_accepted:
+        type: boolean
+        description: |
+          Cliente acepta recibir beneficios relacionados con el producto prepago
+        example: false
+  


### PR DESCRIPTION
Se agrega recurso para:

- Aceptar los terminos y condiciones de prepago en la version indicada
- Aceptar recibir beneficios relacionados con la tarjeta prepago