### PR TITLE
Fix/actualiza documentacion prepaid 1

### DIFF
--- a/api-prepaid.yml
+++ b/api-prepaid.yml
@@ -1483,6 +1483,10 @@ definitions:
     required:
       - code
     properties:
+      traceId:
+        type: string
+        description: Id interno del mensaje
+        example: "201906051704040564"
       code:
         type: integer
         format: int32

--- a/api-prepaid.yml
+++ b/api-prepaid.yml
@@ -1169,6 +1169,8 @@ definitions:
             description: Lista de variables para usar en el voucher
             items:
               $ref: '#/definitions/variable_data'
+            example: [{"name" : "amount_paid", "value" : "3.300"},
+                      {"name" : "rut", "value" : "17.680.522-6"}]
           timestamps:
             $ref: '#/definitions/timestamps'
 

--- a/api-prepaid.yml
+++ b/api-prepaid.yml
@@ -1126,7 +1126,7 @@ definitions:
           password:
             type: integer
             description: La clave del usuario
-            example: 1324
+            example: 132465
             
   variable_data:
     type: object

--- a/api-prepaid.yml
+++ b/api-prepaid.yml
@@ -1169,10 +1169,6 @@ definitions:
             description: Lista de variables para usar en el voucher
             items:
               $ref: '#/definitions/variable_data'
-          user_id:
-            type: integer
-            description: Identificador del Cliente Multicaja afectado
-            example: 1291020
           timestamps:
             $ref: '#/definitions/timestamps'
 


### PR DESCRIPTION
Comparando con las respuestas que dio tenpo en UAT, se hicieron los siguientes cambios a la documentacion destinada a Nelson:

- Se agrego el campo tracerId a los mensajes de error.
- Se elimino userId de la resuesta de cash-in y cash-out dado que este campo ya no viene
- Se agrego como ejemplo el rut en los valores del voucher, que es algo que tambien se observo en las respuestas de tenp uat.