### PR TITLE
Elimina el tracerId de los mensajes de error

### DIFF
--- a/api-prepaid.yml
+++ b/api-prepaid.yml
@@ -1481,10 +1481,6 @@ definitions:
     required:
       - code
     properties:
-      traceId:
-        type: string
-        description: Id interno del mensaje
-        example: "201906051704040564"
       code:
         type: integer
         format: int32


### PR DESCRIPTION
Se elimina el tracerId de los errores, porque tenpo lo movio al header.