### PR TITLE
Agrega header requerido de suscription-key

### DIFF
--- a/api-prepaid.yml
+++ b/api-prepaid.yml
@@ -217,9 +217,8 @@ paths:
           name: Ocp-Apim-Subscription-Key
           description: Key de suscripción requerido (es entregado por Tenpo)
           required: true
-          schema: 
-            type: string
-            example: '98s7df89a098f98shs7df'
+          type: string
+          example: '98s7df89a098f98shs7df'
         - in: body
           name: new_topup
           description: Detalle de la carga a realizar
@@ -334,16 +333,14 @@ paths:
           name: Ocp-Apim-Subscription-Key
           description: Key de subscripción requerido (es entregado por Tenpo)
           required: true
-          schema:
-            type: string
-            example: '98s7df89a098f98shs7df'
+          type: string
+          example: '98s7df89a098f98shs7df'
         - in: header
           name: user-timezone
           description: La zona horaria del cliente (default America/Santiago)
           required: false
-          schema:
-            type: string
-            example: 'America/Santiago'
+          type: string
+          example: 'America/Santiago'
         - in: body
           name: new_topup
           description: Detalle de la carga a realizar
@@ -490,9 +487,8 @@ paths:
           name: Ocp-Apim-Subscription-Key
           description: Key de subscripción requerido (es entregado por Tenpo)
           required: true
-          schema:
-            type: string
-            example: '98s7df89a098f98shs7df'
+          type: string
+          example: '98s7df89a098f98shs7df'
         - in: body
           name: new_withdrawal
           description: Detalle del retiro a realizar
@@ -607,16 +603,14 @@ paths:
           name: Ocp-Apim-Subscription-Key
           description: Key de subscripción requerido (es entregado por Tenpo)
           required: true
-          schema:
-            type: string
-            example: '98s7df89a098f98shs7df'
+          type: string
+          example: '98s7df89a098f98shs7df'
         - in: header
           name: user-timezone
           description: La zona horaria del cliente (default America/Santiago)
           required: false
-          schema:
-            type: string
-            example: 'America/Santiago'
+          type: string
+          example: 'America/Santiago'
         - in: body
           name: new_withdrawal
           description: Detalle de la carga a realizar

--- a/api-prepaid.yml
+++ b/api-prepaid.yml
@@ -215,10 +215,9 @@ paths:
       parameters:
         - in: header
           name: Ocp-Apim-Subscription-Key
-          description: Key de suscripción requerido (es entregado por Tenpo)
+          description: Key de subscripción requerido (es entregado por Tenpo)
           required: true
           type: string
-          example: '98s7df89a098f98shs7df'
         - in: body
           name: new_topup
           description: Detalle de la carga a realizar
@@ -334,13 +333,11 @@ paths:
           description: Key de subscripción requerido (es entregado por Tenpo)
           required: true
           type: string
-          example: '98s7df89a098f98shs7df'
         - in: header
           name: user-timezone
           description: La zona horaria del cliente (default America/Santiago)
           required: false
           type: string
-          example: 'America/Santiago'
         - in: body
           name: new_topup
           description: Detalle de la carga a realizar
@@ -488,7 +485,6 @@ paths:
           description: Key de subscripción requerido (es entregado por Tenpo)
           required: true
           type: string
-          example: '98s7df89a098f98shs7df'
         - in: body
           name: new_withdrawal
           description: Detalle del retiro a realizar
@@ -604,13 +600,11 @@ paths:
           description: Key de subscripción requerido (es entregado por Tenpo)
           required: true
           type: string
-          example: '98s7df89a098f98shs7df'
         - in: header
           name: user-timezone
           description: La zona horaria del cliente (default America/Santiago)
           required: false
           type: string
-          example: 'America/Santiago'
         - in: body
           name: new_withdrawal
           description: Detalle de la carga a realizar

--- a/api-prepaid.yml
+++ b/api-prepaid.yml
@@ -174,6 +174,8 @@ paths:
       tags:
         - prepaid
       summary: Carga una tarjeta
+      consumes:
+        - application/json
       description: |
         Carga una tarjeta
         
@@ -185,6 +187,9 @@ paths:
         ### Responderá `400` en los siguientes casos:
         * 101004: Si un parámetro es requerido y no se ha enviado.
         * 101007: Si un parámetro no cumple formato.
+
+        ### Responderá `401` en los siguientes casos:
+        * 401: Si faltó incluir la key de suscripción en el header, o si la key es incorrecta.
 
         ### Responderá `404` en los siguientes casos:
         * 102001: Si el cliente no está registrado en Tenpo.
@@ -208,6 +213,13 @@ paths:
         ### Responderá `500` en los siguientes casos:
         * Error imprevisto de sistema
       parameters:
+        - in: header
+          name: Ocp-Apim-Subscription-Key
+          description: Key de suscripción requerido (es entregado por Tenpo)
+          required: true
+          schema: 
+            type: string
+            example: '98s7df89a098f98shs7df'
         - in: body
           name: new_topup
           description: Detalle de la carga a realizar
@@ -289,6 +301,8 @@ paths:
       tags:
         - prepaid
       summary: Reversa una carga
+      consumes:
+        - application/json
       description: |
         Reversa una carga que a) coincida en todos los campos de prepaid_topup_new y b) se haya recibido en las últimas 24 horas.
         
@@ -303,6 +317,9 @@ paths:
         * 101004: Si un parámetro es requerido y no se ha enviado.
         * 101007: Si un parámetro no cumple formato.
 
+        ### Responderá `401` en los siguientes casos:
+        * 401: Si faltó incluir la key de suscripción en el header, o si la key es incorrecta.
+
         ### Responderá `404` en los siguientes casos:
         * 102001: Si el cliente no está registrado en Tenpo.
         * 102003: Si el cliente no tiene prepago.
@@ -313,6 +330,20 @@ paths:
         ### Responderá `422` en los siguientes casos:
         * 130002: Si es que la carga fue recibida y la información de la reversa no concuerda.
       parameters:
+        - in: header
+          name: Ocp-Apim-Subscription-Key
+          description: Key de subscripción requerido (es entregado por Tenpo)
+          required: true
+          schema:
+            type: string
+            example: '98s7df89a098f98shs7df'
+        - in: header
+          name: user-timezone
+          description: La zona horaria del cliente (default America/Santiago)
+          required: false
+          schema:
+            type: string
+            example: 'America/Santiago'
         - in: body
           name: new_topup
           description: Detalle de la carga a realizar
@@ -417,6 +448,8 @@ paths:
       tags:
         - prepaid
       summary: Retira dinero de una tarjeta
+      consumes:
+        - application/json
       description: |
         Debita una tarjeta
         
@@ -428,6 +461,9 @@ paths:
         ### Responderá `400` en los siguientes casos:
         * 101004: Si un parámetro es requerido y no se ha enviado.
         * 101007: Si un parámetro no cumple formato.
+
+        ### Responderá `401` en los siguientes casos:
+        * 401: Si faltó incluir la key de suscripción en el header, o si la key es incorrecta.
 
         ### Responderá `404` en los siguientes casos:
         * 102001: Si el cliente no está registrado en Tenpo.
@@ -450,6 +486,13 @@ paths:
         ### Responderá `500` en los siguientes casos:
         * Error imprevisto de sistema
       parameters:
+        - in: header
+          name: Ocp-Apim-Subscription-Key
+          description: Key de subscripción requerido (es entregado por Tenpo)
+          required: true
+          schema:
+            type: string
+            example: '98s7df89a098f98shs7df'
         - in: body
           name: new_withdrawal
           description: Detalle del retiro a realizar
@@ -531,6 +574,8 @@ paths:
       tags:
         - prepaid
       summary: Reversa un retiro
+      consumes:
+        - application/json
       description: |
         Reversa un retiro que a) coincida en todos los campos de prepaid_withdrawal_new y b) se haya recibido en las últimas 24 horas.
         
@@ -545,6 +590,9 @@ paths:
         * 101004: Si un parámetro es requerido y no se ha enviado.
         * 101007: Si un parámetro no cumple formato.
 
+        ### Responderá `401` en los siguientes casos:
+        * 401: Si faltó incluir la key de suscripción en el header, o si la key es incorrecta.
+
         ### Responderá `404` en los siguientes casos:
         * 102001: Si el cliente no está registrado en Tenpo.
         * 102003: Si el cliente no tiene prepago.
@@ -555,6 +603,20 @@ paths:
         ### Responderá `422` en los siguientes casos:
         * 130002: Si es que el retiro fue recibido la información de la reversa no concuerda.
       parameters:
+        - in: header
+          name: Ocp-Apim-Subscription-Key
+          description: Key de subscripción requerido (es entregado por Tenpo)
+          required: true
+          schema:
+            type: string
+            example: '98s7df89a098f98shs7df'
+        - in: header
+          name: user-timezone
+          description: La zona horaria del cliente (default America/Santiago)
+          required: false
+          schema:
+            type: string
+            example: 'America/Santiago'
         - in: body
           name: new_withdrawal
           description: Detalle de la carga a realizar


### PR DESCRIPTION
Cambio principal:
- Agrega un header Ocp-Apim-Subscription-Key a los 4 movimientos principales, el header es un key de suscripcion requerido para autenticarse. Este header lo entrega Tenpo.
- Agrega el error 401 si es que este key es invalido o no esta incluido en el request.

Cambios secundarios:
- A las 4 operaciones se le indico que "cosumen" json.
- A las reversas les agrega el user-timezone como optativo.